### PR TITLE
transact_token関数に説明パラメータを追加し、DynamoDBへのトークン取引を更新

### DIFF
--- a/tokenMarketHandler/index.mjs
+++ b/tokenMarketHandler/index.mjs
@@ -12,11 +12,11 @@ const TABLE_NAME = process.env.DYNAMODB_TOKEN_TABLE_NAME;
  * トークンを取引する関数
  * @param {string} user_id - ユーザーID
  * @param {number} amount - 増減するトークン量（正の値で追加、負の値で減算）
+ * @param {string} description - 処理の説明（任意）
  */
-export const transact_token = async (user_id, amount) => {
+export const transact_token = async (user_id, amount, description = "Unknown") => {
     const timestamp = new Date().toISOString();
     const transaction_id = `txn_${timestamp}`;
-    const description = amount > 0 ? 'Added tokens' : 'Subtracted tokens';
 
     // トークン残高を取得
     const balanceParams = {
@@ -39,26 +39,22 @@ export const transact_token = async (user_id, amount) => {
             throw new Error('Insufficient tokens: Transaction would result in a negative balance');
         }
 
+        const newBalance = currentBalance + amount;
+
         const params = {
             TableName: TABLE_NAME,
-            Key: { user_id, timestamp },
-            UpdateExpression: `
-                SET
-                    current_tokens = if_not_exists(current_tokens, :start) + :amount,
-                    description = :description,
-                    transaction_id = :transaction_id
-            `,
-            ExpressionAttributeValues: {
-                ':start': 0, // 初期値
-                ':amount': amount,
-                ':description': description,
-                ':transaction_id': transaction_id
-            },
-            ReturnValues: 'UPDATED_NEW'
+            Item: {
+                user_id,
+                timestamp,
+                transaction_id,
+                amount,
+                current_tokens: newBalance,
+                description
+            }
         };
 
-        const result = await dynamoDB.update(params).promise();
-        return { message: `Token transaction successful`, updatedTokens: result.Attributes.current_tokens };
+        await dynamoDB.put(params).promise();
+        return { message: `Token transaction successful`, updatedTokens: newBalance };
     } catch (error) {
         console.error('Error in token transaction:', error);
         throw new Error(error.message);
@@ -70,23 +66,22 @@ export const transact_token = async (user_id, amount) => {
  * @param {string} user_id - ユーザーID
  */
 export const check_token_balance = async (user_id) => {
-    const params = {
-        TableName: TABLE_NAME,
-        KeyConditionExpression: 'user_id = :user_id',
-        ExpressionAttributeValues: {
-            ':user_id': user_id
-        },
-        ProjectionExpression: 'current_tokens', // 必要なフィールドのみ取得
-        Limit: 1, // 最新の値だけを取得する
-        ScanIndexForward: false // 時系列降順で取得
-    };
-
     try {
-        const result = await dynamoDB.query(params).promise();
-        if (result.Items.length === 0) {
-            return { message: 'No token data found', current_tokens: 0 };
-        }
-        return { message: 'Token balance retrieved', current_tokens: result.Items[0].current_tokens };
+        const balanceParams = {
+            TableName: TABLE_NAME,
+            KeyConditionExpression: 'user_id = :user_id',
+            ExpressionAttributeValues: {
+                ':user_id': user_id
+            },
+            ProjectionExpression: 'current_tokens',
+            Limit: 1,
+            ScanIndexForward: false
+        };
+
+        const balanceResult = await dynamoDB.query(balanceParams).promise();
+        const currentBalance = balanceResult.Items.length > 0 ? balanceResult.Items[0].current_tokens : 0;
+
+        return { message: 'Token balance retrieved', current_tokens: currentBalance };
     } catch (error) {
         console.error('Error retrieving token balance:', error);
         throw new Error('Could not retrieve token balance');
@@ -97,14 +92,14 @@ export const check_token_balance = async (user_id) => {
  * メインハンドラ
  */
 export const handler = async (event) => {
-    const { action, user_id, amount } = JSON.parse(event.body);
+    const { action, user_id, amount, description } = JSON.parse(event.body);
 
     try {
         switch (action) {
             case 'transact':
                 return {
                     statusCode: 200,
-                    body: JSON.stringify(await transact_token(user_id, amount))
+                    body: JSON.stringify(await transact_token(user_id, amount, description))
                 };
 
             case 'check':


### PR DESCRIPTION
修正点
descriptionを受け取り、どの関数から処理されたか記録するように変更。
curent_number周りの挙動にミスがあったので修正
通貨確認処理を少し簡略化。